### PR TITLE
Fix invalid css

### DIFF
--- a/src/components/Section.module.css
+++ b/src/components/Section.module.css
@@ -7,5 +7,5 @@
 }
 
 .relative {
-  position: 'relative';
+  position: relative;
 }


### PR DESCRIPTION
Fixes the relative positioning property value being wrapped in quotes, which produces invalid CSS when used with Vite (possibly other bundlers too).